### PR TITLE
className for the container, style rule components for :selected and :hovered states

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,44 @@ Node style component.
 </Ogma>
 ```
 
+### `<NodeStyle.Hovered />`
+
+Node style component.
+
+#### Props
+
+| Prop         | Type                           | Default | Description                                  |
+| ------------ | ------------------------------ | ------- | -------------------------------------------- |
+| `attributes` | `Ogma.HoverNodeOptions`      | `{}`    | Attributes to apply to the hovered node              |
+| `fullOverwrite?`  | `boolean` | `false`  | If `false`, the specified attributes will be merged with the current attributes. If `true`, the attributes applied on hover will be exactly the ones supplied. |
+
+#### Example
+
+```tsx
+<Ogma>
+  <NodeStyle.Hovered attributes={{ color: "red", radius: 10 }} />
+</Ogma>
+```
+
+### `<NodeStyle.Selected />`
+
+Node style component.
+
+#### Props
+
+| Prop         | Type                           | Default | Description                                  |
+| ------------ | ------------------------------ | ------- | -------------------------------------------- |
+| `attributes` | `Ogma.NodeAttributeValue`      | `{}`    | Attributes to apply to the selected node              |
+| `fullOverwrite?`  | `boolean` | `false`  | If `false`, the specified attributes will be merged with the current attributes. If `true`, the attributes applied on selection will be exactly the ones supplied. |
+
+#### Example
+
+```tsx
+<Ogma>
+  <NodeStyle.Selected attributes={{ color: "red", radius: 10 }} />
+</Ogma>
+```
+
 ### `<EdgeStyle />`
 
 Edge style component.
@@ -274,6 +312,44 @@ Edge style component.
 ```tsx
 <Ogma>
   <EdgeStyle attributes={{ color: "red" }} />
+</Ogma>
+```
+
+### `<EdgeStyle.Hovered />`
+
+Edge style component.
+
+#### Props
+
+| Prop         | Type                           | Default | Description                                  |
+| ------------ | ------------------------------ | ------- | -------------------------------------------- |
+| `attributes` | `Ogma.HoveredEdgeOptions`      | `{}`    | Attributes to apply to the Hovered edge              |
+| `fullOverwrite?`  | `boolean` | `false`  | If `false`, the specified attributes will be merged with the current attributes. If `true`, the attributes applied on hover will be exactly the ones supplied. |
+
+#### Example
+
+```tsx
+<Ogma>
+  <EdgeStyle.Hovered attributes={{ color: "red" }} />
+</Ogma>
+```
+
+### `<EdgeStyle.Selected />`
+
+Edge style component.
+
+#### Props
+
+| Prop         | Type                           | Default | Description                                  |
+| ------------ | ------------------------------ | ------- | -------------------------------------------- |
+| `attributes` | `Ogma.EdgeAttributeValue`      | `{}`    | Attributes to apply to the selected edge              |
+| `fullOverwrite?`  | `boolean` | `false`  | If `false`, the specified attributes will be merged with the current attributes. If `true`, the attributes applied on selection will be exactly the ones supplied. | |
+
+#### Example
+
+```tsx
+<Ogma>
+  <EdgeStyle.Selected attributes={{ color: "red" }} />
 </Ogma>
 ```
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ It's unintuitive to implement the layouts as a React component declaratively. We
 import { LayoutService } from './components/LayoutService';
 
 export default function App() {
-  ... // retrive the graph here
+  ... // retreive the graph here
 
   return (<Ogma options={options} graph={graph}>
     <LayoutService />
@@ -235,6 +235,7 @@ Main visualisation component. You can use `onReady` or `ref` prop to get a refer
 | `children?` | `React.ReactNode`      | `null`  | The children of the component, such as `<Popup>` or `<Tooltip>` or your custom component. Ogma instance is avalable to the children components through `useOgma()` hook |
 | `theme?` | `Ogma.Themes`      | `null`  | The theme of the graph. Keep in mind that adding `<NodeStyle>` and `<EdgeStyle>` components will overwrite the theme's styles |
 | `onEventName` | `(event: EventTypes<ND, ED>[K]) => void`      | `null`  | The handler for an [event](https://doc.linkurious.com/ogma/latest/api/events.html). The passed in function should always be the result of the `useEvent` hook to have a stable function identity and avoid reassigning the same handler at every render. |
+| `className?`     | `string`      | `ogma-container`  | className for the ogma container                                                                      |
 
 ### `<NodeStyle />`
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ It's unintuitive to implement the layouts as a React component declaratively. We
 import { LayoutService } from './components/LayoutService';
 
 export default function App() {
-  ... // retreive the graph here
+  ... // retrieve the graph here
 
   return (<Ogma options={options} graph={graph}>
     <LayoutService />

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Edge style component.
 | Prop         | Type                           | Default | Description                                  |
 | ------------ | ------------------------------ | ------- | -------------------------------------------- |
 | `attributes` | `Ogma.EdgeAttributeValue`      | `{}`    | Attributes to apply to the selected edge              |
-| `fullOverwrite?`  | `boolean` | `false`  | If `false`, the specified attributes will be merged with the current attributes. If `true`, the attributes applied on selection will be exactly the ones supplied. | |
+| `fullOverwrite?`  | `boolean` | `false`  | If `false`, the specified attributes will be merged with the current attributes. If `true`, the attributes applied on selection will be exactly the ones supplied. |
 
 #### Example
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -1,6 +1,6 @@
 import OgmaLib, {
   Edge,
-  Node,
+  Node as OgmaNode,
   Point,
   RawGraph,
   NodeGrouping as NodeGroupingTransformation,
@@ -14,8 +14,8 @@ import * as L from "leaflet";
 // components
 import {
   Ogma,
-  NodeStyleRule,
-  EdgeStyleRule,
+  NodeStyle,
+  EdgeStyle,
   StyleClass,
   Tooltip,
   NodeGrouping,
@@ -49,7 +49,7 @@ export default function App() {
 
   // UI states
   const [popupOpen, setPopupOpen] = useState(false);
-  const [clickedNode, setClickedNode] = useState<Node>();
+  const [clickedNode, setClickedNode] = useState<OgmaNode>();
 
   // ogma instance and grouping references
   const ogmaInstanceRef = createRef<OgmaLib>();
@@ -80,7 +80,7 @@ export default function App() {
     x: 0,
     y: 0
   });
-  const [target, setTarget] = useState<Node | Edge | null>();
+  const [target, setTarget] = useState<OgmaNode | Edge | null>();
 
   const requestSetTooltipPosition = useCallback((pos: Point) => {
     requestAnimationFrame(() => setTooltipPosition(pos));
@@ -172,20 +172,41 @@ export default function App() {
       >
         {/* Styling */}
 
-        <NodeStyleRule
+        <NodeStyle
           attributes={{
             radius: (n) => (n?.getData("multiplier") || 1) * nodeSize, // the label is the value os the property name.
             text: {
-              content: (node) => node?.getData("properties.name"),
+              content: (node: OgmaNode) => node?.getData("properties.name"),
               font: "IBM Plex Sans",
               minVisibleSize: 3
             }
           }}
         />
-        <EdgeStyleRule attributes={{ width: edgeWidth }} />
+
+        <NodeStyle.Hovered
+          attributes={{
+            radius: (n) => (n?.getData("multiplier") || 1) * nodeSize * 1.5,
+            color: "#FF0000",
+            halo: {
+              width: 2,
+              color: "#FF0000"
+            }
+          }}
+          fullOverwrite={false}
+        />
+
+        <EdgeStyle attributes={{ width: edgeWidth }} />
         {useClass && (
           <StyleClass name="class" nodeAttributes={styleClassNodeAttributes} />
         )}
+
+        <EdgeStyle.Hovered
+          attributes={{
+            width: (e) => e.getData("weight") * edgeWidth,
+            color: "#FF0000"
+          }}
+          fullOverwrite={false}
+        />
 
         {/* Layout */}
         <LayoutService />

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -4,7 +4,8 @@ import OgmaLib, {
   Point,
   RawGraph,
   NodeGrouping as NodeGroupingTransformation,
-  NodeAttributesValue
+  NodeAttributesValue,
+  Theme
 } from "@linkurious/ogma";
 import { morningBreeze } from "@linkurious/ogma-styles";
 import { useEffect, useState, createRef, useCallback, useMemo } from "react";
@@ -22,8 +23,7 @@ import {
   Popup,
   Geo,
   NodeGroupingProps,
-  useEvent,
-  Theme
+  useEvent
 } from "../../src";
 
 // custom components:

--- a/demo/src/index.css
+++ b/demo/src/index.css
@@ -36,6 +36,12 @@ code {
   min-height: 100vh;
 }
 
+.ogma-container {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 .Logo {
   position: absolute;
   top: 15px;

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,20 +1,19 @@
-import { createContext, useContext, Context } from "react";
+import { createContext, useContext } from "react";
 import OgmaLib from "@linkurious/ogma";
 
-export function createOgmaContext<ND = unknown, ED = unknown>() {
-  return createContext<{ ogma?: OgmaLib<ND, ED> } | null>(null);
+type ContextData = {
+  ogma: OgmaLib<any, any>;
 }
 
-export const OgmaContext = createContext(undefined) as Context<
-  OgmaLib | undefined
->;
+export const OgmaContext = createContext<ContextData | null>(null);
 
 /**
  * This is the hook that allows you to access the Ogma instance.
  * It should only be used in the context of the `Ogma` component.
  */
 export const useOgma = <ND, ED>(): OgmaLib<ND, ED> => {
-  const ogma = useContext(OgmaContext);
-  if (!ogma) throw new Error("useOgma must be used within an OgmaProvider");
-  return ogma;
+  const context = useContext(OgmaContext);
+  if (!context) throw new Error("useOgma must be used within an OgmaProvider");
+  return context.ogma;
 };
+

--- a/src/ogma.tsx
+++ b/src/ogma.tsx
@@ -14,14 +14,13 @@ import OgmaLib, {
   RawGraph,
   EventTypes
 } from "@linkurious/ogma";
-// import { Theme } from "@linkurious/ogma";
+import { Theme } from "@linkurious/ogma";
 import { OgmaContext } from "./context";
 import {
   EventHandlerProps,
   getEventNameFromProp,
   EventHandlers,
-  forEachEventHandler,
-  Theme
+  forEachEventHandler
 } from "./types";
 
 interface OgmaProps<ND, ED> extends EventHandlerProps<EventTypes<ND, ED>> {
@@ -162,7 +161,9 @@ export const OgmaComponent = <ND, ED>(
       ref={(containerRef) => setContainer(containerRef)}
     >
       {ogma && (
-        <OgmaContext.Provider value={ogma}>
+        <OgmaContext.Provider value={{
+          ogma: ogma,
+        }}>
           {ready && children}
         </OgmaContext.Provider>
       )}

--- a/src/ogma.tsx
+++ b/src/ogma.tsx
@@ -30,6 +30,7 @@ interface OgmaProps<ND, ED> extends EventHandlerProps<EventTypes<ND, ED>> {
   graph?: RawGraph<ND, ED>;
   children?: ReactNode;
   theme?: Theme<ND, ED>;
+  className?: string;
 }
 
 const defaultOptions = {};
@@ -41,7 +42,7 @@ export const OgmaComponent = <ND, ED>(
   props: OgmaProps<ND, ED>,
   ref?: Ref<OgmaLib<ND, ED>>
 ) => {
-  const { options = defaultOptions, children, graph, onReady, theme } = props;
+  const { options = defaultOptions, children, graph, onReady, theme, className = "ogma-container" } = props;
   const eventHandlersRef = useRef<EventHandlers<ND, ED>>({});
   const [ready, setReady] = useState(false);
   const [ogma, setOgma] = useState<OgmaLib | undefined>();
@@ -157,7 +158,7 @@ export const OgmaComponent = <ND, ED>(
 
   return (
     <div
-      style={{ width: "100%", height: "100%" }}
+      className={className}
       ref={(containerRef) => setContainer(containerRef)}
     >
       {ogma && (

--- a/src/styles/edgeStyle.tsx
+++ b/src/styles/edgeStyle.tsx
@@ -1,7 +1,8 @@
 import OgmaLib, {
   EdgeSelector,
   EdgeAttributesValue,
-  StyleRule
+  StyleRule,
+  HoverEdgeOptions
 } from "@linkurious/ogma";
 import {
   useEffect,
@@ -17,7 +18,18 @@ interface EdgeRuleProps<ND, ED> {
   attributes: EdgeAttributesValue<ED, ND>;
 }
 
-const EdgeStyleRuleComponent = <ND, ED>(
+interface HoveredEdgeProps<ND, ED> {
+  attributes: HoverEdgeOptions<ED, ND>;
+  fullOverwrite?: boolean;
+}
+
+interface SelectedEdgeProps<ND, ED> {
+  attributes: EdgeAttributesValue<ED, ND>;
+  fullOverwrite?: boolean;
+}
+
+
+const EdgeStyleComponent = forwardRef(<ND, ED>(
   { selector, attributes }: EdgeRuleProps<ND, ED>,
   ref?: Ref<StyleRule<ND, ED>>
 ) => {
@@ -38,10 +50,34 @@ const EdgeStyleRuleComponent = <ND, ED>(
     };
   }, [selector, attributes]);
   return null;
+});
+
+const Hovered = <ND, ED>(
+  { attributes, fullOverwrite }: HoveredEdgeProps<ND, ED>,
+) => {
+  const ogma = useOgma() as OgmaLib<ND, ED>;
+
+  useEffect(() => {
+    ogma.styles.setHoveredEdgeAttributes(attributes, fullOverwrite);
+  }, [attributes, fullOverwrite]);
+  return null;
+}
+
+const Selected = <ND, ED>(
+  { attributes, fullOverwrite }: SelectedEdgeProps<ND, ED>,
+) => {
+  const ogma = useOgma() as OgmaLib<ND, ED>;
+
+  useEffect(() => {
+    ogma.styles.setSelectedEdgeAttributes(attributes, fullOverwrite);
+  }, [attributes, fullOverwrite]);
+  return null;
 };
 
 /**
  * This component wraps around Ogma [`EdgeStyle` API](https://doc.linkurio.us/ogma/latest/api.html#Ogma-styles-addEdgeRule). It allows you to add a node style rule to the
  * Ogma instance to calculate the visual appearance attributes of the edges.
  */
-export const EdgeStyleRule = forwardRef(EdgeStyleRuleComponent);
+export const EdgeStyle = Object.assign(
+  EdgeStyleComponent, { Hovered, Selected }
+);

--- a/src/styles/edgeStyle.tsx
+++ b/src/styles/edgeStyle.tsx
@@ -59,6 +59,10 @@ const Hovered = <ND, ED>(
 
   useEffect(() => {
     ogma.styles.setHoveredEdgeAttributes(attributes, fullOverwrite);
+
+    return () => {
+      ogma.styles.setHoveredEdgeAttributes(null);
+    }
   }, [attributes, fullOverwrite]);
   return null;
 }
@@ -70,6 +74,10 @@ const Selected = <ND, ED>(
 
   useEffect(() => {
     ogma.styles.setSelectedEdgeAttributes(attributes, fullOverwrite);
+
+    return () => {
+      ogma.styles.setSelectedEdgeAttributes(null);
+    };
   }, [attributes, fullOverwrite]);
   return null;
 };

--- a/src/styles/nodeStyle.tsx
+++ b/src/styles/nodeStyle.tsx
@@ -1,7 +1,8 @@
 import OgmaLib, {
   NodeSelector,
   NodeAttributesValue,
-  StyleRule
+  StyleRule,
+  HoverNodeOptions
 } from "@linkurious/ogma";
 import {
   useEffect,
@@ -17,7 +18,17 @@ interface NodeRuleProps<ND, ED> {
   attributes: NodeAttributesValue<ND, ED>;
 }
 
-const NodeStyleRuleComponent = <ND, ED>(
+interface HoveredNodeProps<ND, ED> {
+  attributes: HoverNodeOptions<ND, ED>;
+  fullOverwrite?: boolean;
+}
+
+interface SelectedNodeProps<ND, ED> {
+  attributes: NodeAttributesValue<ND, ED>;
+  fullOverwrite?: boolean;
+}
+
+const NodeStyleComponent = forwardRef(<ND, ED>(
   { selector, attributes }: NodeRuleProps<ND, ED>,
   ref?: Ref<StyleRule<ND, ED>>
 ) => {
@@ -37,10 +48,34 @@ const NodeStyleRuleComponent = <ND, ED>(
     };
   }, [selector, attributes]);
   return null;
+});
+
+const Hovered = <ND, ED>(
+  { attributes, fullOverwrite }: HoveredNodeProps<ND, ED>,
+) => {
+  const ogma = useOgma() as OgmaLib<ND, ED>;
+
+  useEffect(() => {
+    ogma.styles.setHoveredNodeAttributes(attributes, fullOverwrite);
+  }, [attributes, fullOverwrite]);
+  return null;
 };
+
+const Selected = <ND, ED>(
+  { attributes, fullOverwrite }: SelectedNodeProps<ND, ED>,
+) => {
+  const ogma = useOgma() as OgmaLib<ND, ED>;
+
+  useEffect(() => {
+    ogma.styles.setSelectedNodeAttributes(attributes, fullOverwrite);
+  }, [attributes, fullOverwrite]);
+  return null;
+}
 
 /**
  * This component wraps around Ogma [`NodeStyle` API](https://doc.linkurio.us/ogma/latest/api.html#Ogma-styles-addNodeRule). It allows you to add a node style rule to the
  * Ogma instance to calculate the visual appearance attributes of the nodes.
  */
-export const NodeStyleRule = forwardRef(NodeStyleRuleComponent);
+export const NodeStyle = Object.assign(
+  NodeStyleComponent, { Hovered, Selected }
+);

--- a/src/styles/nodeStyle.tsx
+++ b/src/styles/nodeStyle.tsx
@@ -57,6 +57,10 @@ const Hovered = <ND, ED>(
 
   useEffect(() => {
     ogma.styles.setHoveredNodeAttributes(attributes, fullOverwrite);
+
+    return () => {
+      ogma.styles.setHoveredNodeAttributes(null);
+    };
   }, [attributes, fullOverwrite]);
   return null;
 };
@@ -68,6 +72,10 @@ const Selected = <ND, ED>(
 
   useEffect(() => {
     ogma.styles.setSelectedNodeAttributes(attributes, fullOverwrite);
+
+    return () => {
+      ogma.styles.setSelectedNodeAttributes(null);
+    };
   }, [attributes, fullOverwrite]);
   return null;
 }

--- a/src/transformations/edgeFilter.tsx
+++ b/src/transformations/edgeFilter.tsx
@@ -44,7 +44,7 @@ function EdgeFilterComponent<ND = any, ED = any>(
     if (transformation) {
       toggle(transformation, !!props.disabled, props.duration);
     }
-  }, [props.disabled]);
+  }, [props.disabled, props.duration]);
 
   useEffect(() => {
     transformation?.setOptions(props);

--- a/src/transformations/nodeFilter.tsx
+++ b/src/transformations/nodeFilter.tsx
@@ -45,7 +45,7 @@ function NodeFilterComponent<ND = any, ED = any>(
     if (transformation) {
       toggle(transformation, !!props.disabled, props.duration);
     }
-  }, [props.disabled]);
+  }, [props.disabled, props.duration]);
 
   useEffect(() => {
     transformation?.setOptions(props);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,20 +1,6 @@
 import {
-  EdgeAttributes,
-  EventTypes,
-  HoverEdgeOptions,
-  HoverNodeOptions,
-  NodeAttributes
+  EventTypes
 } from "@linkurious/ogma";
-
-// temporary while the type import gets added
-export interface Theme<NodeData = unknown, EdgeData = unknown> {
-  nodeAttributes?: NodeAttributes;
-  edgeAttributes?: EdgeAttributes;
-  selectedNodeAttributes?: NodeAttributes;
-  selectedEdgeAttributes?: EdgeAttributes;
-  hoveredNodeAttributes?: HoverNodeOptions<NodeData, EdgeData>;
-  hoveredEdgeAttributes?: HoverEdgeOptions<EdgeData, NodeData>;
-}
 
 export type EventNames<ND, ED> = keyof EventTypes<ND, ED>;
 

--- a/test/ogma.test.tsx
+++ b/test/ogma.test.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { render, waitFor } from "./utils";
 
-import OgmaLib, { RawGraph } from "@linkurious/ogma";
+import OgmaLib, { RawGraph, Theme } from "@linkurious/ogma";
 import { Ogma, useOgma } from "../src";
-import { Theme } from "../src/types";
 import { afternoonNap, morningBreeze } from '@linkurious/ogma-styles';
 import { vi, describe, it, expect, beforeEach } from "vitest";
 

--- a/test/styles.test.tsx
+++ b/test/styles.test.tsx
@@ -1,7 +1,7 @@
 import React, { act, createRef } from "react";
 import { Root, createRoot } from "react-dom/client";
 import { userEvent, waitFor } from "./utils";
-import OgmaLib from "@linkurious/ogma";
+import OgmaLib, { Edge } from "@linkurious/ogma";
 import { Ogma, NodeStyle, EdgeStyle } from "../src";
 import graph from "./fixtures/simple_graph.json";
 
@@ -117,6 +117,7 @@ describe("styles", async () => {
     const node = ogma.getNodes().get(0);
     await ogma.mouse.move(ogma.view.graphToScreenCoordinates(node.getPosition()));
     await ogma.view.afterNextFrame();
+    await ogma.view.afterNextFrame();
     expect(node.getAttribute("color")).toStrictEqual("red");
     await ogma.mouse.move({x: -1000, y: -1000});
     await ogma.view.afterNextFrame();
@@ -218,6 +219,39 @@ describe("styles", async () => {
       "grey",
       "grey"
     ]);
+  });
+
+  it("Sets the attributes for hovered edges correctly", async () => {
+    const ref = createRef<OgmaLib>();
+    act(() =>
+      div.render(
+        <Ogma graph={graph} ref={ref}>
+          <EdgeStyle.Hovered
+            attributes={{ color: "red" }}
+          />
+          <EdgeStyle
+            attributes={{ color: "grey" }}
+          />
+        </Ogma>
+      )
+    );
+    await waitFor(() => expect(ref.current).toBeTruthy());
+    const ogma = ref.current!;
+    let edge = ogma.getEdges().get(0);
+    const src = edge.getSource();
+    const dest = edge.getTarget();
+    const midpoint = {
+      x: (src.getPosition().x + dest.getPosition().x) / 2,
+      y: (src.getPosition().y + dest.getPosition().y) / 2,
+    };
+    await ogma.mouse.move(ogma.view.graphToScreenCoordinates(midpoint));
+    await ogma.view.afterNextFrame();
+    await ogma.view.afterNextFrame();
+    edge = ogma.getHoveredElement() as Edge;
+    expect(edge.getAttribute("color")).toStrictEqual("red");
+    await ogma.mouse.move({x: -1000, y: -1000});
+    await ogma.view.afterNextFrame();
+    expect(edge.getAttribute("color")).toStrictEqual("grey");
   });
 
   it("EdgeStyle cleans up after being removed", async () => {

--- a/test/styles.test.tsx
+++ b/test/styles.test.tsx
@@ -2,7 +2,7 @@ import React, { act, createRef } from "react";
 import { Root, createRoot } from "react-dom/client";
 import { userEvent, waitFor } from "./utils";
 import OgmaLib from "@linkurious/ogma";
-import { Ogma, NodeStyleRule, EdgeStyleRule } from "../src";
+import { Ogma, NodeStyle, EdgeStyle } from "../src";
 import graph from "./fixtures/simple_graph.json";
 
 describe("styles", async () => {
@@ -18,7 +18,7 @@ describe("styles", async () => {
     act(() =>
       div.render(
         <Ogma graph={graph}>
-          <NodeStyleRule attributes={{ color: "red" }} />
+          <NodeStyle attributes={{ color: "red" }} />
         </Ogma>
       )
     );
@@ -29,7 +29,7 @@ describe("styles", async () => {
     act(() =>
       div.render(
         <Ogma graph={graph} ref={ref}>
-          <NodeStyleRule attributes={{ color: "red" }} />
+          <NodeStyle attributes={{ color: "red" }} />
         </Ogma>
       )
     );
@@ -48,7 +48,7 @@ describe("styles", async () => {
     act(() =>
       div.render(
         <Ogma graph={graph} ref={ref}>
-          <NodeStyleRule
+          <NodeStyle
             attributes={{ color: "red" }}
             selector={(node) => Number(node.getId()) < 2}
           />
@@ -65,6 +65,64 @@ describe("styles", async () => {
     ]);
   });
 
+  it("Sets the attributes for selected nodes correctly", async () => {
+    const ref = createRef<OgmaLib>();
+    act(() =>
+      div.render(
+        <Ogma graph={graph} ref={ref}>
+          <NodeStyle.Selected
+            attributes={{ color: "red" }}
+            fullOverwrite
+          />
+          <NodeStyle
+            attributes={{ color: "grey" }}
+          />
+        </Ogma>
+      )
+    );
+    await waitFor(() => expect(ref.current).toBeTruthy());
+    const ogma = ref.current!;
+    const nodes = ogma.getNodes();
+    nodes.setSelected(true);
+    expect(nodes.getAttribute("color")).toStrictEqual([
+      "red",
+      "red",
+      "red",
+    ]);
+    nodes.setSelected(false);
+    await ogma.view.afterNextFrame();
+    expect(nodes.getAttribute("color")).toStrictEqual([
+      "grey",
+      "grey",
+      "grey",
+    ]);
+  });
+
+  it("Sets the attributes for hovered nodes correctly", async () => {
+    const ref = createRef<OgmaLib>();
+    act(() =>
+      div.render(
+        <Ogma graph={graph} ref={ref}>
+          <NodeStyle.Hovered
+            attributes={{ color: "red" }}
+          />
+          <NodeStyle
+            attributes={{ color: "grey" }}
+          />
+        </Ogma>
+      )
+    );
+    await waitFor(() => expect(ref.current).toBeTruthy());
+    const ogma = ref.current!;
+    const node = ogma.getNodes().get(0);
+    await ogma.mouse.move(ogma.view.graphToScreenCoordinates(node.getPosition()));
+    await ogma.view.afterNextFrame();
+    expect(node.getAttribute("color")).toStrictEqual("red");
+    await ogma.mouse.move({x: -1000, y: -1000});
+    await ogma.view.afterNextFrame();
+    expect(node.getAttribute("color")).toStrictEqual("grey");
+  });
+
   it("NodeStyle cleans up after being removed", async () => {
     const ref = createRef<OgmaLib>();
     const Test = () => {
@@ -72,7 +130,7 @@ describe("styles", async () => {
       return (
         <Ogma graph={graph} ref={ref}>
           <button onClick={() => setStyle(!style)}>Click</button>
-          {style && <NodeStyleRule attributes={{ color: "red" }} />}
+          {style && <NodeStyle attributes={{ color: "red" }} />}
         </Ogma>
       );
     };
@@ -87,7 +145,7 @@ describe("styles", async () => {
     act(() =>
       div.render(
         <Ogma graph={graph}>
-          <EdgeStyleRule attributes={{ color: "red" }} />
+          <EdgeStyle attributes={{ color: "red" }} />
         </Ogma>
       )
     );
@@ -98,7 +156,7 @@ describe("styles", async () => {
     act(() =>
       div.render(
         <Ogma graph={graph} ref={ref}>
-          <EdgeStyleRule attributes={{ color: "red" }} />
+          <EdgeStyle attributes={{ color: "red" }} />
         </Ogma>
       )
     );
@@ -116,7 +174,7 @@ describe("styles", async () => {
     act(() =>
       div.render(
         <Ogma graph={graph} ref={ref}>
-          <EdgeStyleRule
+          <EdgeStyle
             attributes={{ color: "green" }}
             selector={(edge) => Number(edge.getId()) > 0}
           />
@@ -131,6 +189,37 @@ describe("styles", async () => {
     ]);
   });
 
+  it("Sets the attributes for selected edges correctly", async () => {
+    const ref = createRef<OgmaLib>();
+    act(() =>
+      div.render(
+        <Ogma graph={graph} ref={ref}>
+          <EdgeStyle.Selected
+            attributes={{ color: "red" }}
+            fullOverwrite
+          />
+          <EdgeStyle
+            attributes={{ color: "grey" }}
+          />
+        </Ogma>
+      )
+    );
+    await waitFor(() => expect(ref.current).toBeTruthy());
+    const ogma = ref.current!;
+    const edges = ogma.getEdges();
+    edges.setSelected(true);
+    expect(edges.getAttribute("color")).toStrictEqual([
+      "red",
+      "red"
+    ]);
+    edges.setSelected(false);
+    await ogma.view.afterNextFrame();
+    expect(edges.getAttribute("color")).toStrictEqual([
+      "grey",
+      "grey"
+    ]);
+  });
+
   it("EdgeStyle cleans up after being removed", async () => {
     const ref = createRef<OgmaLib>();
     const Test = () => {
@@ -138,7 +227,7 @@ describe("styles", async () => {
       return (
         <Ogma graph={graph} ref={ref}>
           <button onClick={() => setStyle(!style)}>Click</button>
-          {style && <EdgeStyleRule attributes={{ color: "red" }} />}
+          {style && <EdgeStyle attributes={{ color: "red" }} />}
         </Ogma>
       );
     };


### PR DESCRIPTION
- removed the initial styling for the ogma container and added a class as a prop for the container
- added the duration of the nodefilter and edgefilter as a dependency
- added the hover and selected states to the styling APIs for edges and nodes
- added the documentation for the previous points
- added the new components to the example
- modified the test imports and added tests for selected (and maybe hovered) nodes / edges