### PR TITLE
Prevent pointer events on invisible box for tooltips

### DIFF
--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -177,7 +177,7 @@ export default function App() {
         />
 
         <Tooltip
-          eventName="nodeHover"
+          eventName="nodeRightclick"
           bodyClass="ogma-tooltip"
         >
           {(target) => {

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -179,6 +179,7 @@ export default function App() {
         <Tooltip
           eventName="nodeRightclick"
           bodyClass="ogma-tooltip"
+          placement="right"
         >
           {(target) => {
             return (

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -177,8 +177,7 @@ export default function App() {
         />
 
         <Tooltip
-          eventName="nodeRightclick"
-          placement="right"
+          eventName="nodeHover"
           bodyClass="ogma-tooltip"
         >
           {(target) => {

--- a/src/overlay/tooltip.tsx
+++ b/src/overlay/tooltip.tsx
@@ -98,7 +98,7 @@ const TooltipComponent = <K extends keyof TooltipEventFunctions>(
       position: position ? position : offScreenPos,
       element: `
       <div style="pointer-events: none">
-        <div class="${bodyClass}" style="transform: ${transform}">
+        <div class="${bodyClass}" style="transform: ${transform}; pointer-events: auto">
         </div>
       </div>`,
       size: size || { width: "auto", height: "auto" },

--- a/src/overlay/tooltip.tsx
+++ b/src/overlay/tooltip.tsx
@@ -97,7 +97,7 @@ const TooltipComponent = <K extends keyof TooltipEventFunctions>(
     const currentLayer = ogma.layers.addOverlay({
       position: position ? position : offScreenPos,
       element: `
-      <div>
+      <div style="pointer-events: none">
         <div class="${bodyClass}" style="transform: ${transform}">
         </div>
       </div>`,


### PR DESCRIPTION
The tooltip component had an invisible box that had pointer events enabled, which can prevent clicks on the graph